### PR TITLE
Added escape function

### DIFF
--- a/interrobang.c
+++ b/interrobang.c
@@ -227,6 +227,21 @@ static int main_loop() {
 	return (breakcode == 1 ? 1 : 0);
 }
 
+static char * escape(const char * line) {
+    char * escaped_str = malloc(strlen(line) * 2);
+    char * output = escaped_str;
+    while (*line) {
+        switch (*line) {
+            case '(': case ')': case '[': case ']':
+                *output++ = '\\';
+            default:
+                *output++ = *line++;
+        }
+    }
+    *output++ = '\0';
+    return escaped_str;
+}
+
 static int process_command() {
 	int i, x = 0; char *c, *b = NULL;
 	strcpy(cmd,"");
@@ -243,7 +258,7 @@ static int process_command() {
 		else if (b)	sprintf(cmd,b, line + 1);
 	}
 	else {
-		strcpy(cmd,line);
+		strcpy(cmd,escape(line));
 	} 
 	strcat(cmd," &");
 	if (strlen(cmd) > 2) system(cmd);


### PR DESCRIPTION
Escapes '(', ')', '[', ']' from the file name that is generated by
compgen.

I tried with with a file called `bg()[asdf].jpg` and tab completion works. However if a file was name `(bg.jpg` the tab completion will fail, even though the file opens successfully.
